### PR TITLE
질문/댓글 신고횟수 변경, 댓글 조회 변경

### DIFF
--- a/src/main/java/com/banchan/model/dto/reviews/ReviewsResponseDto.java
+++ b/src/main/java/com/banchan/model/dto/reviews/ReviewsResponseDto.java
@@ -14,6 +14,7 @@ public class ReviewsResponseDto {
     private Integer questionId;
     private Integer uesrId;
     private String content;
+    private Integer reportState;
     private String createdAt;
     private String updatedAt;
 
@@ -22,6 +23,7 @@ public class ReviewsResponseDto {
         this.questionId = entity.getQuestionId();
         this.uesrId = entity.getUesrId();
         this.content = entity.getContent();
+        this.reportState = entity.getReportState();
         this.createdAt = toStringDateTime(entity.getCreatedAt());
         this.updatedAt = toStringDateTime(entity.getUpdatedAt());
     }

--- a/src/main/java/com/banchan/repository/ReviewsRepository.java
+++ b/src/main/java/com/banchan/repository/ReviewsRepository.java
@@ -11,7 +11,6 @@ public interface ReviewsRepository extends JpaRepository<Reviews, Integer> {
     @Query(value = "SELECT * FROM reviews " +
             "WHERE " +
             "question_id = :questionId " +
-            "AND report_state = 0 " +
             "AND delete_state = 0 " +
             "AND id < :lastReviewId " +
             "ORDER BY created_at DESC " +

--- a/src/main/java/com/banchan/service/question/QuestionsService.java
+++ b/src/main/java/com/banchan/service/question/QuestionsService.java
@@ -118,7 +118,7 @@ public class QuestionsService {
     /**
      * 신고 테이블에 저장. REPORT_MAX_SIZE 이상 신고되면 게시글 신고상태값 변경
      */
-    final static int REPORT_MAX_SIZE = 5;
+    final static int REPORT_MAX_SIZE = 10;
     @Transactional
     public Integer saveReport(ReportRequestDto dto) {
         Integer questionId = reportsRepository.save(dto.toQuestionReportEntity()).getId();

--- a/src/main/java/com/banchan/service/reviews/ReviewsService.java
+++ b/src/main/java/com/banchan/service/reviews/ReviewsService.java
@@ -50,7 +50,7 @@ public class ReviewsService {
     /**
      * 신고 테이블에 저장. REPORT_MAX_SIZE 이상 신고되면 댓글 신고상태값 변경
      */
-    final static int REPORT_MAX_SIZE = 5;
+    final static int REPORT_MAX_SIZE = 10;
     @Transactional
     public Integer saveReport(ReportRequestDto dto) {
         Integer reportId = reportsRepository.save(dto.toReviewReportEntity()).getId();


### PR DESCRIPTION
- 질문/댓글 신고 횟수 10으로 변경
- 댓글은 누적 신고 횟수 10이 넘어도 조회가 안되는게 아니라 조회는 하되 내용/작성자만 안보이게 해야함
=> 해당 댓글이 신고상태인지 알 수 있게 reportState값 (0이면 미신고, 1이면 신고) 데이터 목록에 추가
- 삭제된 댓글은 그대로 조회시 안보임
